### PR TITLE
Clarify routee paths do not support full path under cluster #25935

### DIFF
--- a/akka-docs/src/main/paradox/cluster-routing.md
+++ b/akka-docs/src/main/paradox/cluster-routing.md
@@ -60,8 +60,8 @@ the router will try to use them as soon as the member status is changed to 'Up'.
 
 @@@
 
-The actor paths without address information that are defined in `routees.paths` are used for selecting the
-actors to which the messages will be forwarded to by the router.
+The actor paths that are defined in `routees.paths` are used for selecting the
+actors to which the messages will be forwarded to by the router. The path should not contain protocol and address information because they are retrieved dynamically from the cluster membership. 
 Messages will be forwarded to the routees using @ref:[ActorSelection](actors.md#actorselection), so the same delivery semantics should be expected.
 It is possible to limit the lookup of routees to member nodes tagged with a particular set of roles by specifying `use-roles`.
 


### PR DESCRIPTION
Refs [#25935](https://github.com/akka/akka/issues/25935)